### PR TITLE
fix pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     data_files=[ ('doc', [
         'CHANGES.txt',
         'LICENSE.txt',
-        'README.markdown',
+        'README.md',
         ]
     )],
     install_requires = ['supervisor >= 3.0a10'],


### PR DESCRIPTION
pip install throws an error, README.markdown file doesnt exist. fixes name
